### PR TITLE
Multi-process support for data download

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ from dataset.fivek import MITAboveFiveK
 
 data_loader = DataLoader(
     MITAboveFiveK(root="path-to-dataset-root", split="train", download=True, experts=["a"]),
-    batch_size=None, num_workers=1)
+    batch_size=None)
 
 for item in data_loader:
     # Processing as you want.
@@ -139,8 +139,8 @@ from torch.utils.data.dataloader import DataLoader
 from dataset.fivek import MITAboveFiveK
 
 data_loader = DataLoader(
-    MITAboveFiveK(root="/datasets", split="debug", download=True, experts=["a", "c"]),
-    batch_size=None, num_workers=1)
+    MITAboveFiveK(root="/datasets", split="debug", download=True, experts=["a", "c"], download_workers=4),
+    batch_size=None)
 item = next(iter(data_loader))
 print(item)
 # 

--- a/dataset/fivek.py
+++ b/dataset/fivek.py
@@ -68,9 +68,12 @@ class MITAboveFiveK(Dataset):
             RuntimeError: If dataset not found, or download failed.
     """
 
-    def __init__(
-        self, root: str, split: str, download: bool = False, experts: List[str] = None
-    ) -> None:
+    def __init__(self,
+                 root: str,
+                 split: str,
+                 download: bool = False,
+                 experts: List[str] = None,
+                 download_workers: int = 1) -> None:
         # root directory of datasets
         self.root = root
 
@@ -95,7 +98,7 @@ class MITAboveFiveK(Dataset):
                 dataset_dir=self.dataset_dir,
                 config_name="per_camera_model",
                 experts=self.experts,
-            ).build(split=self.split)
+            ).build(split=self.split, num_workers=download_workers)
         else:
             self.metadata = MITAboveFiveKBuilder(
                 dataset_dir=self.dataset_dir,
@@ -127,7 +130,8 @@ class MITAboveFiveK(Dataset):
             if not os.path.isfile(self.metadata[basename]["files"]["dng"]):
                 return False
             for e in self.experts:
-                if not os.path.isfile(self.metadata[basename]["files"]["tiff16"][e]):
+                if not os.path.isfile(
+                        self.metadata[basename]["files"]["tiff16"][e]):
                     return False
         return True
 

--- a/dataset/fivek.py
+++ b/dataset/fivek.py
@@ -39,6 +39,8 @@ class MITAboveFiveK(Dataset):
             split (str): One of {'train', 'val', 'test', 'debug'}. 'debug' uses only 9 data contained in 'train'.
             download (bool): If True, downloads the dataset from the official urls. Files that already exist locally will skip the download. Defaults to False.
             experts (List[str]): List of {'a', 'b', 'c', 'd', 'e'}. 'a' means 'Expert A' in the website <https://data.csail.mit.edu/graphics/fivek/>. Defaults to None.
+            download_workers (int):  How many subprocesses to use for data downloading.
+                                     None means that min(32, cpu_count() + 4). (default: 1)
 
     Notes:
             Expects the following folder structure if download=False:

--- a/dataset/fivek_builder.py
+++ b/dataset/fivek_builder.py
@@ -315,13 +315,16 @@ class MITAboveFiveKBuilder:
         else:
             item["files"] = {"dng": filepath}
 
-    def build(self, split: str = None, num_workers: int = 1) -> Dict[str, Any]:
+    def build(self,
+              split: str = None,
+              num_workers: int = None) -> Dict[str, Any]:
         """
         Builds the dataset.
 
         Args:
             split (str): One of {'train', 'val', 'test', 'debug'}. If None, build data of all splits.
-
+            num_workers (int):  How many subprocesses to use for data downloading.
+                                None means that min(32, cpu_count() + 4). (default: None)
         Returns:
             Dict[str]: metadata of builded dataset.
             The format of metadata is as follows.
@@ -407,9 +410,13 @@ class MITAboveFiveKBuilder:
             if self.redownload or not os.path.isfile(path):
                 download(self.JSON_URLS[key], path)
 
-    def download_raw(self, num_workers: int = 1) -> None:
+    def download_raw(self, num_workers: int = None) -> None:
         """
         Downloads the raw dataset.
+
+        Args:
+            num_workers (int):  How many subprocesses to use for data downloading.
+                                None means that min(32, cpu_count() + 4). (default: None)
 
         Raises:
             RuntimeError: Error rises if downloading the raw dataset fails.
@@ -436,10 +443,14 @@ class MITAboveFiveKBuilder:
                         max_workers=num_workers,
                         desc="Downloading (dng) ")
 
-    def download_experts(self, num_workers: int = 1):
+    def download_experts(self, num_workers: int = None):
         """
         Download expert images for each image in the dataset.
         The expert images are saved in the processed directory in TIFF format.
+
+        Args:
+            num_workers (int):  How many subprocesses to use for data downloading.
+                                None means that min(32, cpu_count() + 4). (default: None)
 
         Raises:
             RuntimeError: Error rises if downloading expert images fails.

--- a/sample_processing.py
+++ b/sample_processing.py
@@ -10,7 +10,12 @@ Arguments:
     dir_root    Path of the root directory where the directory 'MITAboveFiveK' exists.
     
     [Options]
-    --to_dir    Path to a directory to save developed images. If None, save to `root_dir`/MITAboveFiveK/processed/sRGB/.
+    --to_dir    Path to a directory to save developed images. 
+                If None, save to `root_dir`/MITAboveFiveK/processed/sRGB/.
+    --experts [{a,b,c,d,e} ...]
+                List of experts who adjusted tone of the photos to download. 
+                Experts are 'a', 'b', 'c', 'd', and/or 'e'.
+    --workers   How many subprocesses to use for data downloading.
     -h, --help  Show the help message and exit.
 
 Example:
@@ -70,6 +75,20 @@ def main():
         help=
         "Path to a directory to save developed images. If None, save to `root_dir`/MITAboveFiveK/processed/sRGB/.",
     )
+    parser.add_argument(
+        "--experts",
+        nargs="*",
+        choices=["a", "b", "c", "d", "e"],
+        help=
+        "List of experts who adjusted tone of the photos to download. Experts are 'a', 'b', 'c', 'd', and/or 'e'.",
+        default=None,
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        help="How many subprocesses to use for data downloading.",
+        default=4,
+    )
 
     args = parser.parse_args()
     if not args.to_dir:
@@ -80,8 +99,8 @@ def main():
     data_loader = DataLoader(MITAboveFiveK(root=args.root_dir,
                                            split="debug",
                                            download=True,
-                                           download_workers=4,
-                                           experts=['a', 'b']),
+                                           download_workers=args.workers,
+                                           experts=args.experts),
                              batch_size=None)
     for item in data_loader:
         print(item)

--- a/sample_processing.py
+++ b/sample_processing.py
@@ -53,39 +53,43 @@ from dataset.fivek import MITAboveFiveK
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Develop and save raw images of the FiveK dataset using RawPy."
-    )
+        description=
+        "Develop and save raw images of the FiveK dataset using RawPy.")
     parser.add_argument(
         "root_dir",
         type=str,
         default=".cache",
-        help="Path of the root directory where the directory 'MITAboveFiveK' exists.",
+        help=
+        "Path of the root directory where the directory 'MITAboveFiveK' exists.",
     )
     parser.add_argument(
         "--to_dir",
         type=str,
         default=None,
         required=False,
-        help="Path to a directory to save developed images. If None, save to `root_dir`/MITAboveFiveK/processed/sRGB/.",
+        help=
+        "Path to a directory to save developed images. If None, save to `root_dir`/MITAboveFiveK/processed/sRGB/.",
     )
 
     args = parser.parse_args()
     if not args.to_dir:
-        args.to_dir = os.path.join(args.root_dir, "MITAboveFiveK", "processed", "sRGB")
+        args.to_dir = os.path.join(args.root_dir, "MITAboveFiveK", "processed",
+                                   "sRGB")
     os.makedirs(args.to_dir, exist_ok=True)
 
-    data_loader = DataLoader(
-        MITAboveFiveK(root=args.root_dir, split="debug", download=True),
-        batch_size=None,
-        num_workers=1,
-    )
+    data_loader = DataLoader(MITAboveFiveK(root=args.root_dir,
+                                           split="debug",
+                                           download=True,
+                                           download_workers=4,
+                                           experts=['a', 'b']),
+                             batch_size=None)
     for item in data_loader:
+        print(item)
         # Some kind of process using FiveK
         raw = rawpy.imread(item["files"]["dng"])
         srgb = raw.postprocess()
         Image.fromarray(srgb).save(
-            os.path.join(args.to_dir, f"{item['basename']}.jpeg")
-        )
+            os.path.join(args.to_dir, f"{item['basename']}.jpeg"))
 
 
 if __name__ == "__main__":

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -27,6 +27,7 @@ class FiveKTestCase(unittest.TestCase):
     cache_dir = ".cache"
     dataset_dir = ".cache/MITAboveFiveK"
     categories_labels = ["location", "time", "light", "subject"]
+    download_workers = 4
 
     def check_metadata(self, metadata: Dict[str, Any]):
         for value in metadata.values():

--- a/tests/test_fivek.py
+++ b/tests/test_fivek.py
@@ -28,27 +28,41 @@ from tests.test_common import FiveKTestCase
 
 
 class TestMITAboveFiveK(FiveKTestCase):
+
     def test_init(self):
         MITAboveFiveK(self.cache_dir, "debug")
 
     def test_init_with_download(self):
-        MITAboveFiveK(self.cache_dir, "debug", download=True)
+        MITAboveFiveK(self.cache_dir,
+                      "debug",
+                      download=True,
+                      download_workers=self.download_workers)
 
     def test_init_no_data(self):
         shutil.rmtree(self.dataset_dir)
-        self.assertRaises(
-            RuntimeError, MITAboveFiveK, self.cache_dir, "debug", download=False
-        )
+        self.assertRaises(RuntimeError,
+                          MITAboveFiveK,
+                          self.cache_dir,
+                          "debug",
+                          download=False)
 
     def test_init_with_data(self):
-        MITAboveFiveK(self.cache_dir, "debug", download=True)
+        MITAboveFiveK(self.cache_dir,
+                      "debug",
+                      download=True,
+                      download_workers=self.download_workers)
         MITAboveFiveK(self.cache_dir, "debug", download=False)
 
     def test___len__(self):
-        assert MITAboveFiveK(self.cache_dir, "debug", download=True).__len__() == 9
+        assert MITAboveFiveK(
+            self.cache_dir,
+            "debug",
+            download=True,
+            download_workers=self.download_workers).__len__() == 9
 
 
 class TestMITAboveFiveKWithDataLoader(FiveKTestCase):
+
     def test_load_with_dataloader(self):
         metadata_loader = DataLoader(
             MITAboveFiveK(self.cache_dir, "debug", download=True),

--- a/tests/test_fivek_builder.py
+++ b/tests/test_fivek_builder.py
@@ -55,7 +55,7 @@ class TestMITAboveFiveKBuilderBuild(FiveKTestCase):
         shutil.rmtree(self.cache_dir)
         builder = MITAboveFiveKBuilder(self.dataset_dir,
                                        config_name="per_camera_model")
-        res = builder.build(split="debug")
+        res = builder.build(split="debug", num_workers=self.download_workers)
         assert len(res.keys()) == 9
         self.check_metadata(res)
 
@@ -87,7 +87,7 @@ class TestMITAboveFiveKBuilderPath(FiveKTestCase):
         )
         builder = MITAboveFiveKBuilder(self.dataset_dir,
                                        config_name="per_camera_model")
-        builder.build("debug")
+        builder.build(split="debug", num_workers=self.download_workers)
         actual = builder.raw_file_path("a0298-IMG_5043")
         assert expected == actual
 
@@ -100,7 +100,7 @@ class TestMITAboveFiveKBuilderPath(FiveKTestCase):
                 config_name=config.name,
                 experts=["e"],
             )
-            builder.build("debug")
+            builder.build(split="debug", num_workers=self.download_workers)
             actual = builder.expert_file_path("a0298-IMG_5043", "e")
             assert expected == actual
 


### PR DESCRIPTION
- class `MITAboveFiveK`: The number of workers for data download can now be specified as `download_workers`
- class `MITAboveFiveKBuilder`  
  - build(): The number of workers for data download can now be specified as `num_workers`
  - download_raw(): The number of workers for data download can now be specified as `num_workers`
  -  download_experts(): The number of workers for data download can now be specified as `num_workers`
- `sample_preprocessing.py`: Support for multi-process download
- `README.md`: Changed the example to use multi-process.